### PR TITLE
Create EDA notebook for Alzheimer's dataset

### DIFF
--- a/eda_alzheimers.ipynb
+++ b/eda_alzheimers.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exploratory Data Analysis of Alzheimer's Disease Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Load Data and Initial Exploration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Load the dataset\n",
+    "df = pd.read_csv('alzheimers_disease_data.csv')\n",
+    "\n",
+    "# Display the first 5 rows\n",
+    "print('First 5 rows of the dataset:')\n",
+    "print(df.head())\n",
+    "\n",
+    "# Display the data types of each column\n",
+    "print('\\nData types of each column:')\n",
+    "print(df.dtypes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Descriptive Statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Calculate and display descriptive statistics for numerical columns\n",
+    "print('\\nDescriptive statistics for numerical columns:')\n",
+    "print(df.describe())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Feature Engineering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Feature Engineering\n",
+    "# Drop confidential columns\n",
+    "df = df.drop(columns=['Diagnosis', 'DoctorInCharge'])\n",
+    "\n",
+    "# One-hot encode categorical features\n",
+    "df = pd.get_dummies(df, columns=['Ethnicity', 'Gender'], drop_first=True)\n",
+    "\n",
+    "print('\\nDataFrame after feature engineering:')\n",
+    "print(df.head())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Time-Series Plot of Memory Complaints"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Time-Series Plot of MemoryComplaints over Age\n",
+    "plt.figure(figsize=(12, 6))\n",
+    "plt.plot(df['Age'], df['MemoryComplaints'], marker='o', linestyle='-')\n",
+    "plt.title('Memory Complaints Over Age')\n",
+    "plt.xlabel('Age')\n",
+    "plt.ylabel('Memory Complaints')\n",
+    "plt.grid(True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Top Features Correlated with Forgetfulness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Top 3 Features Bar Chart\n",
+    "# Calculate the correlation with 'Forgetfulness'\n",
+    "correlation_matrix = df.corr()\n",
+    "forgetfulness_corr = correlation_matrix['Forgetfulness'].abs().sort_values(ascending=False)\n",
+    "\n",
+    "# Get the top 3 features (excluding 'Forgetfulness' itself)\n",
+    "top_3_features = forgetfulness_corr[1:4]\n",
+    "\n",
+    "print('\\nTop 3 features correlated with Forgetfulness:')\n",
+    "print(top_3_features)\n",
+    "\n",
+    "# Create a bar chart\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "top_3_features.plot(kind='bar')\n",
+    "plt.title('Top 3 Features Correlated with Forgetfulness')\n",
+    "plt.xlabel('Features')\n",
+    "plt.ylabel('Absolute Correlation')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This notebook performs exploratory data analysis on the `alzheimers_disease_data.csv` dataset.

The notebook includes the following steps:
- Loads the data using pandas.
- Displays the first 5 rows and data types.
- Calculates and displays descriptive statistics.
- Performs feature engineering, including one-hot encoding of categorical variables and dropping confidential columns.
- Visualizes memory complaints over age.
- Identifies and visualizes the top 3 features correlated with forgetfulness, which is used as a proxy for Alzheimer's diagnosis.